### PR TITLE
Fix 2.13.2.2 micro-patch release notes

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,7 +8,7 @@ Project: jackson-databind
 
 ...
 
-2.13.2 (28-Mar-2022)
+2.13.2.2 (28-Mar-2022)
 
 No changes since 2.13.2.1 but fixed Gradle Module Metadata ("module.json")
 


### PR DESCRIPTION
Listed as '2.13.2' instead of '2.13.2.2'